### PR TITLE
Fix description breaking html `'`

### DIFF
--- a/full-list-categorized.json
+++ b/full-list-categorized.json
@@ -347,7 +347,7 @@
     "<span lang='Hushed face woo shh'></span> 😯",
     "<span lang='Frowning face aw what'></span> 😦",
     "<span lang='Anguished face stunned nervous'></span> 😧",
-    "<span lang='Cry face tears sad depressed upset :'('></span> 😢",
+    "<span lang='Cry face tears sad depressed upset'></span> 😢",
     "<span lang='Disappointed Relieved face phew sweat nervous'></span> 😥",
     "<span lang='Drooling Face face'></span> 🤤",
     "<span lang='Sleepy face tired rest nap'></span> 😪",

--- a/full-list.txt
+++ b/full-list.txt
@@ -71,7 +71,7 @@
 <span lang='Hushed face woo shh'></span> 😯
 <span lang='Frowning face aw what'></span> 😦
 <span lang='Anguished face stunned nervous'></span> 😧
-<span lang='Cry face tears sad depressed upset :'('></span> 😢
+<span lang='Cry face tears sad depressed upset'></span> 😢
 <span lang='Disappointed Relieved face phew sweat nervous'></span> 😥
 <span lang='Drooling Face face'></span> 🤤
 <span lang='Sleepy face tired rest nap'></span> 😪

--- a/people.txt
+++ b/people.txt
@@ -69,7 +69,7 @@
 <span lang='Hushed face woo shh'></span> 😯
 <span lang='Frowning face aw what'></span> 😦
 <span lang='Anguished face stunned nervous'></span> 😧
-<span lang='Cry face tears sad depressed upset :'('></span> 😢
+<span lang='Cry face tears sad depressed upset'></span> 😢
 <span lang='Disappointed Relieved face phew sweat nervous'></span> 😥
 <span lang='Drooling Face face'></span> 🤤
 <span lang='Sleepy face tired rest nap'></span> 😪


### PR DESCRIPTION
There is one description breaking the html by accidentally closing the `''`.
Fixed it (backport).